### PR TITLE
Feat #47113436 Дополнил механику игры

### DIFF
--- a/packages/client/src/features/GameCanvas/model/hocs/useGameControls.ts
+++ b/packages/client/src/features/GameCanvas/model/hocs/useGameControls.ts
@@ -2,9 +2,30 @@ import { KeyboardEvent, useEffect, useState } from 'react'
 import { Direction } from '@/features/GameCanvas/model/types'
 import { DEFAULT_SPEED } from '@/features/GameCanvas/model/gameConstant'
 
-export const useGameControls = (): { direction: Direction; speed: number } => {
+export const useGameControls = (): {
+  direction: Direction
+  speed: number
+  increaseSpeed: () => void
+} => {
   const [direction, setDirection] = useState<Direction>(Direction.ArrowRight)
   const [speed, setSpeed] = useState<number>(DEFAULT_SPEED)
+  const [isBoosted, setIsBoosted] = useState<boolean>(false)
+
+  const increaseSpeed = () => {
+    setSpeed(prevSpeed => {
+      return prevSpeed / 1.1
+    })
+  }
+
+  const toggleBoost = () => {
+    setIsBoosted(isBoosted => {
+      setSpeed(prevSpeed => {
+        return !isBoosted ? prevSpeed / 2 : prevSpeed * 2
+      })
+
+      return !isBoosted
+    })
+  }
 
   useEffect(() => {
     const handleKeyDown = (event: Event): void => {
@@ -44,12 +65,7 @@ export const useGameControls = (): { direction: Direction; speed: number } => {
           })
           break
         case 'Space':
-          setSpeed(prevSpeed => {
-            if (DEFAULT_SPEED === prevSpeed) {
-              return prevSpeed / 5
-            }
-            return DEFAULT_SPEED
-          })
+          toggleBoost()
           break
       }
     }
@@ -58,5 +74,5 @@ export const useGameControls = (): { direction: Direction; speed: number } => {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [])
 
-  return { direction, speed }
+  return { direction, speed, increaseSpeed }
 }

--- a/packages/client/src/features/GameCanvas/ui/GameCanvas.tsx
+++ b/packages/client/src/features/GameCanvas/ui/GameCanvas.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Flex, notification } from 'antd'
+import { Flex } from 'antd'
 import { Direction, GameItem, Snake } from '@/features/GameCanvas/model/types'
 import {
   useConfigurateCanvas,
@@ -10,7 +10,11 @@ import { drawGame } from '@/features/GameCanvas/lib/drawGame'
 import { getRandomInt } from '@/features/GameCanvas/lib'
 import s from './GameCanvas.module.css'
 import { useAppDispatch, useAppSelector } from '@/shared/hooks'
-import { setScore, setStatusGame } from '@/widgets/Game/model/gemeSlice'
+import {
+  setScore,
+  setStatusGame,
+  setLevel,
+} from '@/widgets/Game/model/gemeSlice'
 import { StatusGame } from '@/widgets/Game/model/types'
 
 export const GameCanvas = () => {
@@ -20,15 +24,19 @@ export const GameCanvas = () => {
 
   const [snake, setSnake] = useState<Snake>([])
   const [apple, setApple] = useState<GameItem>()
+  const [appleTimeout, setAppleTimeout] = useState<number>(0)
 
   const statusGame = useAppSelector(state => state.game.statusGame)
+  const currentLevel = useAppSelector(state => state.game.level)
+  const currentScore = useAppSelector(state => state.game.score)
+
   const dispatch = useAppDispatch()
 
   const configCanvas = useConfigurateCanvas<HTMLCanvasElement>(
     canvasRef,
     SIZE_OBJECT
   )
-  const { direction, speed } = useGameControls()
+  const { direction, speed, increaseSpeed } = useGameControls()
 
   useEffect(() => {
     if (statusGame === StatusGame.Process) {
@@ -51,8 +59,10 @@ export const GameCanvas = () => {
   }, [configCanvas])
 
   const updateGame = useCallback(() => {
+    //обновляем кадр
     const { width: widthCanvas, height: heightCanvas } = configCanvas.sizeCanvas
     const headNode = snake.at(-1)
+
     if (!headNode || !apple) {
       return
     }
@@ -64,6 +74,12 @@ export const GameCanvas = () => {
       const dopItemSnake: GameItem = transformSnake(newHeadNode)
       newSnake = [...snake.slice(1), newHeadNode, dopItemSnake]
       generateApple()
+      dispatch(setScore(newSnake.length - 1))
+      if (currentScore % 4 === 0) {
+        //каждые 4 яблока это +1 уровень
+        increaseSpeed() //повышаем скорость вместе с уровнем
+        dispatch(setLevel(currentLevel + 1))
+      }
     } else {
       newSnake = [...snake.slice(1), newHeadNode]
     }
@@ -88,7 +104,6 @@ export const GameCanvas = () => {
     } else {
       drawGame(configCanvas, newSnake, apple)
       setSnake(newSnake)
-      dispatch(setScore(newSnake.length - 1))
     }
   }, [configCanvas, snake, direction])
 

--- a/packages/client/src/features/GameCanvas/ui/GameCanvas.tsx
+++ b/packages/client/src/features/GameCanvas/ui/GameCanvas.tsx
@@ -28,7 +28,6 @@ export const GameCanvas = () => {
 
   const statusGame = useAppSelector(state => state.game.statusGame)
   const currentLevel = useAppSelector(state => state.game.level)
-  const currentScore = useAppSelector(state => state.game.score)
 
   const dispatch = useAppDispatch()
 
@@ -50,8 +49,10 @@ export const GameCanvas = () => {
 
   useEffect(() => {
     if (appleLifetime) {
-      clearInterval(appleInterval.current)
       appleInterval.current = setInterval(generateApple, appleLifetime)
+    }
+    return () => {
+      clearInterval(appleInterval.current)
     }
   }, [apple])
 
@@ -83,15 +84,13 @@ export const GameCanvas = () => {
       newSnake = [...snake.slice(1), newHeadNode, dopItemSnake]
       generateApple()
       dispatch(setScore(newSnake.length - 1))
-      if (currentScore % 4 === 0) {
-        //каждые 4 яблока это +1 уровень
+      if ((newSnake.length - 1) % 4 === 0) {
         const nextLevel = currentLevel + 1
-        increaseSpeed() //повышаем скорость вместе с уровнем
+        increaseSpeed()
         dispatch(setLevel(nextLevel))
         if (nextLevel > 1 && nextLevel < 20) {
           setAppleLifetime(oldAppleLifetime => {
-            //выставляем таймер для яблока
-            return !oldAppleLifetime ? 20000 : oldAppleLifetime - 1000 //отнимаем секунду за каждый уровень
+            return !oldAppleLifetime ? 20000 : oldAppleLifetime - 1000
           })
         }
       }

--- a/packages/client/src/features/GameInfo/ui/GameInfo.tsx
+++ b/packages/client/src/features/GameInfo/ui/GameInfo.tsx
@@ -16,6 +16,7 @@ export const GameInfo: FC = () => {
   const navigate = useNavigate()
 
   const score = useAppSelector(state => state.game.score)
+  const currentLevel = useAppSelector(state => state.game.level)
   const statusGame = useAppSelector(state => state.game.statusGame)
   const dispatch = useAppDispatch()
 
@@ -63,6 +64,10 @@ export const GameInfo: FC = () => {
         <p>
           <span className={s.gameDescriptionTitle}>Съедено яблок: </span>
           {score}
+        </p>
+        <p>
+          <span className={s.gameDescriptionTitle}>Текущий уровень: </span>
+          {currentLevel}
         </p>
         <p>
           <span className={s.gameDescriptionTitle}>Время с начала игры: </span>

--- a/packages/client/src/widgets/Game/model/gemeSlice.ts
+++ b/packages/client/src/widgets/Game/model/gemeSlice.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { StatusGame } from '@/widgets/Game/model/types/StatusGame'
 import { GameStore } from '@/widgets/Game/model/types'
 
-const initialState: GameStore = {
+export const initialState: GameStore = {
   statusGame: StatusGame.Start,
   score: 0,
   level: 1,
@@ -21,10 +21,12 @@ const gameSlice = createSlice({
     setLevel: (state: GameStore, action: PayloadAction<number>) => {
       state.level = action.payload
     },
+    resetGameStore: () => {
+      return initialState
+    },
   },
 })
 
 export const gameReducer = gameSlice.reducer
-export const setStatusGame = gameSlice.actions.setStatusGame
-export const setScore = gameSlice.actions.setScore
-export const setLevel = gameSlice.actions.setLevel
+export const { setStatusGame, setScore, setLevel, resetGameStore } =
+  gameSlice.actions

--- a/packages/client/src/widgets/Game/model/gemeSlice.ts
+++ b/packages/client/src/widgets/Game/model/gemeSlice.ts
@@ -5,6 +5,7 @@ import { GameStore } from '@/widgets/Game/model/types'
 const initialState: GameStore = {
   statusGame: StatusGame.Start,
   score: 0,
+  level: 1,
 }
 
 const gameSlice = createSlice({
@@ -17,9 +18,13 @@ const gameSlice = createSlice({
     setScore: (state: GameStore, action: PayloadAction<number>) => {
       state.score = action.payload
     },
+    setLevel: (state: GameStore, action: PayloadAction<number>) => {
+      state.level = action.payload
+    },
   },
 })
 
 export const gameReducer = gameSlice.reducer
 export const setStatusGame = gameSlice.actions.setStatusGame
 export const setScore = gameSlice.actions.setScore
+export const setLevel = gameSlice.actions.setLevel

--- a/packages/client/src/widgets/Game/model/types/GameStore.ts
+++ b/packages/client/src/widgets/Game/model/types/GameStore.ts
@@ -3,4 +3,5 @@ import { StatusGame } from '@/widgets/Game/model/types/StatusGame'
 export type GameStore = {
   statusGame: StatusGame
   score: number
+  level: number
 }

--- a/packages/client/src/widgets/StartGame/index.tsx
+++ b/packages/client/src/widgets/StartGame/index.tsx
@@ -2,6 +2,8 @@ import { FC, useState } from 'react'
 import { Button, Flex } from 'antd'
 import styles from './Start.module.css'
 import { CounterAnimation } from '@/shared/ui'
+import { useAppDispatch } from '@/shared/hooks'
+import { resetGameStore } from '../Game/model/gemeSlice'
 
 interface IStartGameProps {
   playGame: () => void
@@ -10,6 +12,7 @@ interface IStartGameProps {
 export const StartGame: FC<IStartGameProps> = ({ playGame }) => {
   const [started, setStarted] = useState(false)
   const [isAnimationComplete, setIsAnimationComplete] = useState(false)
+  const dispatch = useAppDispatch()
 
   const startAnimation = () => {
     setStarted(true)
@@ -29,7 +32,10 @@ export const StartGame: FC<IStartGameProps> = ({ playGame }) => {
             className={styles.button}
             type="primary"
             size="large"
-            onClick={startAnimation}>
+            onClick={() => {
+              startAnimation()
+              dispatch(resetGameStore())
+            }}>
             <span className={styles['button-text']}>Старт</span>
           </Button>
         )}


### PR DESCRIPTION
### Какую задачу решаем
Добавил стейт "уровень" для игры. Теперь каждые 4 съеденных яблока будут повышать уровень игры на 1, а также увеличивать скорость змейки (около 5% за каждый лвл).

Добавил resetGameStore в gameSlice, чтоб при рестарте сбрасывались все параметры до дефолтных (счет, уровень)

Добавил время жизни для яблока. С повышением уровня время будет сокращаться.

### Скриншоты/видяшка (если есть)

### TBD (если есть)